### PR TITLE
The Sequence-based GPT2 Model is not Training

### DIFF
--- a/dataset.py
+++ b/dataset.py
@@ -147,7 +147,7 @@ def pair_frags(fname, out, method='Recap', is_mf=True):
         subs = np.array([m for m in subs if m.GetNumAtoms() > 1])
         match = np.array([[m.HasSubstructMatch(f) for f in subs] for m in subs])
         frags = subs[match.sum(axis=0) == 1]
-        frags = sorted(frags, key=lambda x:-x.GetNumAtoms())[:voc.n_frags]
+        frags = sorted(frags, key=lambda x:-x.GetNumAtoms())[:4]
         frags = [Chem.MolToSmiles(Chem.RemoveHs(f)) for f in frags]
 
         max_comb = len(frags) if is_mf else 1
@@ -249,17 +249,17 @@ if __name__ == '__main__':
     is_mf = bool(OPT.get('-f', 1))
     BATCH_SIZE = 256
 
-    corpus('data/LIGAND_RAW.tsv', 'data/ligand', suffix='tsv')
-    corpus('data/chembl_27.sdf.gz', 'data/chembl')
+    corpus('data/chembl_30_1000.smi', 'data/chembl', suffix='smi')
+    #corpus('data/chembl_27.sdf.gz', 'data/chembl')
 
-    voc = utils.VocGraph('data/voc_graph.txt', n_frags=4)
-    voc_smi = utils.VocSmiles('data/voc_smiles.txt')
+    #voc = utils.VocGraph('data/voc_graph.txt', n_frags=4)
+    voc_smi = Voc('data/voc_smiles.txt')
     out = 'data/%s_%s_%s' % (dataset, 'mf' if is_mf else 'sf', method)
     pair_frags('data/chembl_corpus.txt', out + '.txt', method=method, is_mf=is_mf)
-    pair_frags('data/ligand_corpus.txt', out + '.txt', method=method, is_mf=is_mf)
+    # pair_frags('data/ligand_corpus.txt', out + '.txt', method=method, is_mf=is_mf)
     train_test_split('data/chembl_mf_brics.txt', 'data/chembl_mf_brics')
-    train_test_split('data/ligand_mf_brics.txt', 'data/ligand_mf_brics')
-    for ds in ['train']:
-        pair_graph_encode(out + '_%s.txt' % ds, voc, out + '_%s_code.txt' % ds)
+    # train_test_split('data/ligand_mf_brics.txt', 'data/ligand_mf_brics')
+    for ds in ['train', 'test']:
+        # pair_graph_encode(out + '_%s.txt' % ds, voc, out + '_%s_code.txt' % ds)
         pair_smiles_encode(out + '_%s.txt' % ds, voc_smi, out + '_%s_smi.txt' % ds)
-    pos_neg_split()
+    # pos_neg_split()

--- a/models/generator.py
+++ b/models/generator.py
@@ -1,3 +1,4 @@
+import os
 import torch
 import utils
 from torch import nn
@@ -8,6 +9,7 @@ import pandas as pd
 
 class Base(nn.Module):
     def fit(self, pair_loader, ind_loader, epochs=100, method=None, out=None):
+        os.makedirs(os.path.dirname(out), exist_ok=True) # create output directory if it does not exist yet
         log = open(out + '.log', 'w')
         best = 0.
         net = nn.DataParallel(self, device_ids=utils.devices)

--- a/train_smiles.py
+++ b/train_smiles.py
@@ -31,7 +31,7 @@ def rl_train():
     case = OPT['-c'] if '-c' in OPT else 'OBJ1'
     z = OPT['-z'] if '-z' in OPT else 'REG'
     alg = OPT['-a'] if '-a' in OPT else 'smile'
-    os.environ["CUDA_VISIBLE_DEVICES"] = OPT['-g'] if '-g' in OPT else "0,1,2,3"
+    #os.environ["CUDA_VISIBLE_DEVICES"] = OPT['-g'] if '-g' in OPT else "3,4,5,6"
 
     voc = utils.VocSmiles(init_from_file="data/voc_smiles.txt", max_len=100)
     agent = GPT2Model(voc, n_layer=12)
@@ -82,19 +82,16 @@ if __name__ == "__main__":
     opts, args = getopt.getopt(sys.argv[1:], "m:g:b:d:")
     OPT = dict(opts)
     torch.cuda.set_device(0)
-    os.environ["CUDA_VISIBLE_DEVICES"] = OPT.get('-g', "0,1,2,3")
+    #os.environ["CUDA_VISIBLE_DEVICES"] = OPT.get('-g', "4,5")
     method = OPT.get('-m', 'gpt')
-    step = OPT['-s']
-    BATCH_SIZE = int(OPT.get('-b', '256'))
-    dataset = OPT.get('-d', 'ligand_mf_brics')
+    # step = OPT['-s']
+    BATCH_SIZE = int(OPT.get('-b', '64'))
+    dataset = OPT.get('-d', 'chembl_mf_brics')
 
     data = pd.read_table('data/%s_train_smi.txt' % dataset)
     test = pd.read_table('data/%s_test_smi.txt' % dataset)
-    test = test.Input.drop_duplicates().sample(BATCH_SIZE * 10).values
-    if method in ['gpt']:
-        voc = utils.Voc('data/voc_smiles.txt', src_len=100, trg_len=100)
-    else:
-        voc = utils.VocSmiles('data/voc_smiles.txt', max_len=100)
+    test = test.Input.drop_duplicates().sample(BATCH_SIZE).values
+    voc = utils.VocSmiles('data/voc_smiles.txt', max_len=100) # had to change this to VocSmiles because the Voc class does not have max_len, maybe that is the problem?
     data_in = voc.encode([seq.split(' ') for seq in data.Input.values])
     data_out = voc.encode([seq.split(' ') for seq in data.Output.values])
     data_set = TensorDataset(data_in, data_out)
@@ -105,4 +102,4 @@ if __name__ == "__main__":
     test_loader = DataLoader(test_set, batch_size=BATCH_SIZE, collate_fn=test_set.collate_fn)
 
     pretrain(method=method)
-    rl_train()
+    # rl_train()

--- a/utils/objective.py
+++ b/utils/objective.py
@@ -321,7 +321,7 @@ class Env:
         for j, smile in enumerate(smiles):
             try:
                 mol = Chem.MolFromSmiles(smile)
-                valids[j, 0] = 0 if mol is None else 1
+                valids[j, 0] = 0 if mol is None or not smile else 1 # empty smiles should also be invalid even if empty molecule is valid in rdkit
             except:
                 valids[j, 0] = 0
             if frags is not None:

--- a/utils/vocab.py
+++ b/utils/vocab.py
@@ -4,6 +4,8 @@ from rdkit import Chem
 from rdkit.Chem.MolStandardize import rdMolStandardize
 import numpy as np
 import pandas as pd
+from torch.utils.data import Dataset
+
 import utils
 
 


### PR DESCRIPTION
Hi @XuhanLiu,

I tried to pretrain the `GPT2Model` with your scripts, but even on a large data set of compounds (see below) the validity of the SMILES does not increase and indeed the SMILES that are output in the log file are invalid and also do not contain the desired fragments. It seems the model can learn atom type distributions, but the connectivity is not working.

I also had to make some adjustments to make the scripts work for `GPT2Model`, hence the pull request (see the changes in the commit of this PR). Please, check if it makes sense because I struggled to guess the correct vocabulary class to use in particular. The contents of my data folder with an example data set of 10k compounds can be downloaded [here](https://drive.google.com/file/d/1xnKqjNJYzzeAP7kE-otesPDKe9UIJjFn/view?usp=sharing). With that data in place I just run the scripts as follows so it should be easy for you to reproduce:

```
python dataset.py
python train_smiles.py
```

But even on 1 mil. compounds I still get the following after more than 600 epochs:

```
Epoch: 658 step: 0 loss: 1.217 valid: 0.145 desire: 0.000 time: 16
Epoch: 659 step: 0 loss: 1.249 valid: 0.117 desire: 0.000 time: 16
Epoch: 660 step: 0 loss: 1.244 valid: 0.125 desire: 0.000 time: 16
Epoch: 661 step: 0 loss: 1.250 valid: 0.117 desire: 0.000 time: 16
Epoch: 662 step: 0 loss: 1.228 valid: 0.121 desire: 0.000 time: 16
Epoch: 663 step: 0 loss: 1.188 valid: 0.141 desire: 0.000 time: 16
Epoch: 664 step: 0 loss: 1.255 valid: 0.129 desire: 0.000 time: 16
Epoch: 665 step: 0 loss: 1.223 valid: 0.102 desire: 0.000 time: 16
Epoch: 666 step: 0 loss: 1.212 valid: 0.113 desire: 0.000 time: 16
Epoch: 667 step: 0 loss: 1.206 valid: 0.133 desire: 0.000 time: 16
Epoch: 668 step: 0 loss: 1.248 valid: 0.129 desire: 0.000 time: 16
```

Would you be so kind and take a look at what I am doing wrong? Many thanks!

PS: The graph-based model works great so thanks for that!